### PR TITLE
added mpi parallelization to noise_gen/sim scripts

### DIFF
--- a/scripts/noise_gen.py
+++ b/scripts/noise_gen.py
@@ -1,4 +1,4 @@
-from pixell import utils as putils
+from pixell import mpi as p_mpi
 from mnms import noise_models as nm, utils
 import argparse
 import numpy as np
@@ -38,7 +38,7 @@ if args.use_mpi:
     from mpi4py import MPI
     comm = MPI.COMM_WORLD
 else:
-    comm = putils.FakeCommunicator()
+    comm = p_mpi.FakeCommunicator()
         
 model = nm.BaseNoiseModel.from_config(args.config_name, args.noise_model_name, *args.qid)
 

--- a/scripts/noise_sim.py
+++ b/scripts/noise_sim.py
@@ -1,3 +1,4 @@
+from pixell import utils as putils
 from mnms import noise_models as nm, utils
 import argparse
 import numpy as np
@@ -43,7 +44,18 @@ parser.add_argument('--maps-step', dest='maps_step', type=int, default=1,
 
 parser.add_argument('--alm', dest='alm', default=False, 
                     action='store_true', help='Generate simulated alms instead of maps.')
+
+parser.add_argument('--use-mpi', action='store_true',
+                    help='Use MPI to compute simulations in parallel.')
+
 args = parser.parse_args()
+
+if args.use_mpi:
+    # Could add try statement, but better to crash if MPI cannot be imported.
+    from mpi4py import MPI
+    comm = MPI.COMM_WORLD
+else:
+    comm = putils.FakeCommunicator()
 
 model = nm.BaseNoiseModel.from_config(args.config_name, args.noise_model_name, *args.qid)
 
@@ -63,10 +75,22 @@ else:
     maps = np.arange(args.maps_start, args.maps_end+args.maps_step, args.maps_step)
 assert np.all(maps >= 0)
 
-# Iterate over sims
-for s in splits:
-    for m in maps:
-        model.get_sim(s, m, args.lmax, alm=args.alm, write=True, verbose=True,
-                      **args.subproduct_kwargs)
-    model.cache_clear('model')
-    model.cache_clear('sqrt_ivar')
+# Most common use with MPI should be many sims for small number of
+# splits, so we try to put sims with equal split index on the same rank
+splits_and_maps = np.asarray([(s, m) for s in splits for m in maps])
+splits_and_maps_on_rank = np.array_split(splits_and_maps, comm.size)[comm.rank]
+
+for idx, (s, m) in enumerate(splits_and_maps_on_rank):
+    model.get_sim(s, m, args.lmax, alm=args.alm, write=True, verbose=True,
+                  **args.subproduct_kwargs)
+
+    # Get split number in next iteration of loop.
+    try:
+        s_next, _ = splits_and_maps_on_rank[idx+1]
+    except IndexError:
+        continue
+    else:
+        # Clear model if we're going to work on a different split next iteration.
+        if s_next != s:
+            model.cache_clear('model')
+            model.cache_clear('sqrt_ivar')

--- a/scripts/noise_sim.py
+++ b/scripts/noise_sim.py
@@ -1,4 +1,4 @@
-from pixell import utils as putils
+from pixell import mpi as p_mpi
 from mnms import noise_models as nm, utils
 import argparse
 import numpy as np
@@ -55,7 +55,7 @@ if args.use_mpi:
     from mpi4py import MPI
     comm = MPI.COMM_WORLD
 else:
-    comm = putils.FakeCommunicator()
+    comm = p_mpi.FakeCommunicator()
 
 model = nm.BaseNoiseModel.from_config(args.config_name, args.noise_model_name, *args.qid)
 


### PR DESCRIPTION
This adds MPI parallelization to `noise_gen.py` and `noise_sim.py` to either compute models or sims in parallel. To keep things backwards compatible, MPI will only be used when `--use-mpi` is added to the scripts. Without that option, the script will work without working MPI implementations (to the extent that `pixell` works without MPI)